### PR TITLE
docs: add missing hook configuration step

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -115,6 +115,59 @@ You should see both `diary/` and `reflections/` directories.
    - Run `/reflect`
    - Verify a reflection file was created: `ls -la ~/.claude/memory/reflections/`
 
+### 4. Set Up PreCompact Hook (Optional - For Automatic Diary Generation)
+
+The PreCompact hook automatically generates diary entries before Claude Code compacts long conversations (200+ messages).
+
+**Step 1: Install the hook script**
+
+```bash
+mkdir -p ~/.claude/hooks
+cp hooks/pre-compact.sh ~/.claude/hooks/pre-compact.sh
+chmod +x ~/.claude/hooks/pre-compact.sh
+```
+
+**Step 2: Configure the hook in settings**
+
+Add the following to `~/.claude/settings.json` (global) or `.claude/settings.local.json` (project-specific):
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/pre-compact.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Alternative: Use the interactive command**
+
+```bash
+/hooks
+```
+
+Then select:
+- Hook event: `PreCompact`
+- Matcher: `auto` (for automatic compaction) or `manual` (for `/compact` command)
+- Command: `bash ~/.claude/hooks/pre-compact.sh`
+
+**Verify hook configuration**
+
+Check that your settings file contains the hook configuration:
+
+```bash
+cat ~/.claude/settings.json | grep -A 10 "PreCompact"
+```
+
 ## Troubleshooting
 
 ### "Command not found: /diary"
@@ -152,6 +205,27 @@ You should see both `diary/` and `reflections/` directories.
 1. Run `/diary` first to create some entries
 2. Check that diary files exist: `ls ~/.claude/memory/diary/`
 3. Verify file permissions: `ls -la ~/.claude/memory/diary/`
+
+### PreCompact hook not running
+
+**Problem**: The hook script exists but diary entries aren't being automatically generated before compaction.
+
+**Solutions**:
+1. Check that the hook is configured in `settings.json`:
+   ```bash
+   cat ~/.claude/settings.json | grep -A 10 "PreCompact"
+   ```
+2. Verify the hook script is executable:
+   ```bash
+   ls -la ~/.claude/hooks/pre-compact.sh
+   # Should show -rwxr-xr-x permissions
+   ```
+3. Make it executable if needed:
+   ```bash
+   chmod +x ~/.claude/hooks/pre-compact.sh
+   ```
+4. Check that you have the correct hook configuration (both the script file AND the settings.json configuration are required)
+5. Restart Claude Code after adding hook configuration
 
 ## Updating the Plugin
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,35 @@ cp hooks/pre-compact.sh ~/.claude/hooks/pre-compact.sh
 chmod +x ~/.claude/hooks/pre-compact.sh
 ```
 
-4. **Use the system**:
+4. **Configure the hook in settings**:
+
+   Add the following to `~/.claude/settings.json` (global) or `.claude/settings.local.json` (project-specific):
+
+   ```json
+   {
+     "hooks": {
+       "PreCompact": [
+         {
+           "matcher": "auto",
+           "hooks": [
+             {
+               "type": "command",
+               "command": "bash ~/.claude/hooks/pre-compact.sh"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+   Alternatively, use the interactive command:
+   ```bash
+   /hooks
+   ```
+   Then select `PreCompact` event, `auto` matcher, and enter `bash ~/.claude/hooks/pre-compact.sh` as the command.
+
+5. **Use the system**:
    - Run `/diary` after important sessions (or let the PreCompact hook auto-generate)
    - After any collection of diary entries, run `/reflect` to analyze patterns
    - `CLAUDE.md` automatically updated with learnings


### PR DESCRIPTION
## Problem

The installation documentation only mentioned copying the `pre-compact.sh` hook script to `~/.claude/hooks/` but did
not explain that hooks also need to be configured in `settings.json`.

This caused users to follow all installation steps yet find the PreCompact hook wasn't running, leading to confusion
about whether the feature was working correctly.

## Changes

### README.md
- Added new step 4: "Configure the hook in settings"
- Provided both manual configuration (editing `settings.json`) and interactive (`/hooks` command) methods
- Included complete JSON configuration example with proper syntax
- Renumbered original step 4 to step 5

### INSTALL.md
- Added new section 4: "Set Up PreCompact Hook (Optional - For Automatic Diary Generation)"
- Included complete two-step process: script installation + settings configuration
- Added verification command to check hook configuration: `cat ~/.claude/settings.json | grep -A 10 "PreCompact"`
- Added new troubleshooting section: "PreCompact hook not running" with 5 diagnostic steps

## Key Insight

Both components are required for hooks to work in Claude Code:
1. ✅ Hook script file in `~/.claude/hooks/`
2. ✅ Hook configuration in `settings.json` (this was missing from docs)

## Testing

Confirmed that following the updated documentation results in a properly configured PreCompact hook that
automatically generates diary entries before conversation compaction.